### PR TITLE
replace `getvalueforname` with `getclaimbyid`

### DIFF
--- a/decoder.py
+++ b/decoder.py
@@ -37,7 +37,7 @@ def api_decode(txid, nout):
 def api_decodebyclaim(claimid):
     connection_string = get_lbrycrdd_connection_details()
     rpc = AuthServiceProxy(connection_string)
-    claim = rpc.getvalueforname(claimid)
+    claim = rpc.getclaimbyid(claimid)
     if claim:
         converted = "".join([chr(ord(i)) for i in claim['value']])
         decoded = smart_decode(converted) # Decode the claims and dump them back to logstash plugin


### PR DESCRIPTION
I was talking with Jack yesterday and he suggested you replace `getvalueforname` with `getclaimbyid` because `getvalueforname` resolves a winning claim for a name not an id.  I am not sure if this is a necessary change, as `getvalueforname` seems to be working, but there you go.   `getclaimbyid` is supported in lbrycrd 0.12.0.5. 